### PR TITLE
refactor(Comparable.php): move to core

### DIFF
--- a/src/Api/Model.php
+++ b/src/Api/Model.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Efortmeyer\Polar\Api;
 
-use Efortmeyer\Polar\Core\Entry;
+use Efortmeyer\Polar\Core\{
+    Entry,
+    Comparable,
+};
 
 /**
  * Represents a unit of data.

--- a/src/Core/Comparable.php
+++ b/src/Core/Comparable.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Efortmeyer\Polar\Api;
+namespace Efortmeyer\Polar\Core;
 
 /**
  * Provides support for equality comparison.

--- a/tests/__comparables__/NestedXSSFix.php
+++ b/tests/__comparables__/NestedXSSFix.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Efortmeyer\Polar\Tests\Comparables;
 
-use Efortmeyer\Polar\Api\Comparable;
+use Efortmeyer\Polar\Core\Comparable;
 
 class NestedXSSFix implements Comparable
 {

--- a/tests/__comparables__/NestedXSSFixEnd.php
+++ b/tests/__comparables__/NestedXSSFixEnd.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Efortmeyer\Polar\Tests\Comparables;
 
-use Efortmeyer\Polar\Api\Comparable;
+use Efortmeyer\Polar\Core\Comparable;
 
 class NestedXSSFixEnd implements Comparable
 {

--- a/tests/__comparables__/NestedXSSHack.php
+++ b/tests/__comparables__/NestedXSSHack.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Efortmeyer\Polar\Tests\Comparables;
 
-use Efortmeyer\Polar\Api\Comparable;
+use Efortmeyer\Polar\Core\Comparable;
 
 class NestedXSSHack implements Comparable
 {

--- a/tests/__comparables__/NestedXSSHackEnd.php
+++ b/tests/__comparables__/NestedXSSHackEnd.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Efortmeyer\Polar\Tests\Comparables;
 
-use Efortmeyer\Polar\Api\Comparable;
+use Efortmeyer\Polar\Core\Comparable;
 
 class NestedXSSHackEnd implements Comparable
 {

--- a/tests/__extensions__/PolarTestCaseExtension.php
+++ b/tests/__extensions__/PolarTestCaseExtension.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Efortmeyer\Polar\Tests\Extensions;
 
-use Efortmeyer\Polar\Api\Comparable;
+use Efortmeyer\Polar\Core\Comparable;
 use PHPUnit\Framework\TestCase;
 
 class PolarTestCaseExtension extends TestCase


### PR DESCRIPTION
The interface will not be used for customization so should not be in the Api namespace.

Issue #13, Resolves #13